### PR TITLE
Pass ftnlen as needed.

### DIFF
--- a/src/cgbtrf.c
+++ b/src/cgbtrf.c
@@ -32,7 +32,7 @@ void RELAPACK_cgbtrf(
         *info = -6;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CGBTRF", &minfo);
+        LAPACK(xerbla)("CGBTRF", &minfo, 6);
         return;
     }
 

--- a/src/cgemmt.c
+++ b/src/cgemmt.c
@@ -58,7 +58,7 @@ void RELAPACK_cgemmt(
     else if (*ldC < MAX(1, *n))
         info = 13;
     if (info) {
-        LAPACK(xerbla)("CGEMMT", &info);
+        LAPACK(xerbla)("CGEMMT", &info, 6);
         return;
     }
 

--- a/src/cgetrf.c
+++ b/src/cgetrf.c
@@ -26,7 +26,7 @@ void RELAPACK_cgetrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CGETRF", &minfo);
+        LAPACK(xerbla)("CGETRF", &minfo, 6);
         return;
     }
 

--- a/src/chegst.c
+++ b/src/chegst.c
@@ -36,7 +36,7 @@ void RELAPACK_chegst(
         *info = -7;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CHEGST", &minfo);
+        LAPACK(xerbla)("CHEGST", &minfo, 6);
         return;
     }
 

--- a/src/chetrf.c
+++ b/src/chetrf.c
@@ -56,7 +56,7 @@ void RELAPACK_chetrf(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CHETRF", &minfo);
+        LAPACK(xerbla)("CHETRF", &minfo, 6);
         return;
     }
 

--- a/src/chetrf_rec2.c
+++ b/src/chetrf_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_chetrf_rec2(char *uplo, int *n, int *
 	nb, int *kb, complex *a, int *lda, int *ipiv, complex *w,
-	int *ldw, int *info, ftnlen uplo_len)
+	int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/chetrf_rook.c
+++ b/src/chetrf_rook.c
@@ -56,7 +56,7 @@ void RELAPACK_chetrf_rook(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CHETRF", &minfo);
+        LAPACK(xerbla)("CHETRF", &minfo, 6);
         return;
     }
 

--- a/src/chetrf_rook_rec2.c
+++ b/src/chetrf_rook_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_chetrf_rook_rec2(char *uplo, int *n,
 	int *nb, int *kb, complex *a, int *lda, int *ipiv,
-	complex *w, int *ldw, int *info, ftnlen uplo_len)
+	complex *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/clauum.c
+++ b/src/clauum.c
@@ -28,7 +28,7 @@ void RELAPACK_clauum(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CLAUUM", &minfo);
+        LAPACK(xerbla)("CLAUUM", &minfo, 6);
         return;
     }
 

--- a/src/cpbtrf.c
+++ b/src/cpbtrf.c
@@ -31,7 +31,8 @@ void RELAPACK_cpbtrf(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CPBTRF", &minfo);
+        const int len = 6;
+        LAPACK(xerbla)("CPBTRF", &minfo, &len);
         return;
     }
 

--- a/src/cpotrf.c
+++ b/src/cpotrf.c
@@ -28,7 +28,7 @@ void RELAPACK_cpotrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CPOTRF", &minfo);
+        LAPACK(xerbla)("CPOTRF", &minfo, 6);
         return;
     }
 

--- a/src/csytrf.c
+++ b/src/csytrf.c
@@ -56,7 +56,7 @@ void RELAPACK_csytrf(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CSYTRF", &minfo);
+        LAPACK(xerbla)("CSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/csytrf_rec2.c
+++ b/src/csytrf_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_csytrf_rec2(char *uplo, int *n, int *
 	nb, int *kb, complex *a, int *lda, int *ipiv, complex *w,
-	int *ldw, int *info, ftnlen uplo_len)
+	int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/csytrf_rook.c
+++ b/src/csytrf_rook.c
@@ -56,7 +56,7 @@ void RELAPACK_csytrf_rook(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CSYTRF", &minfo);
+        LAPACK(xerbla)("CSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/csytrf_rook_rec2.c
+++ b/src/csytrf_rook_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_csytrf_rook_rec2(char *uplo, int *n,
 	int *nb, int *kb, complex *a, int *lda, int *ipiv,
-	complex *w, int *ldw, int *info, ftnlen uplo_len)
+	complex *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/ctgsyl.c
+++ b/src/ctgsyl.c
@@ -58,7 +58,7 @@ void RELAPACK_ctgsyl(
         *info = -20;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CTGSYL", &minfo);
+        LAPACK(xerbla)("CTGSYL", &minfo, 6);
         return;
     }
 

--- a/src/ctrsyl.c
+++ b/src/ctrsyl.c
@@ -43,7 +43,7 @@ void RELAPACK_ctrsyl(
         *info = -11;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CTRSYL", &minfo);
+        LAPACK(xerbla)("CTRSYL", &minfo, 6);
         return;
     }
 

--- a/src/ctrsyl_rec2.c
+++ b/src/ctrsyl_rec2.c
@@ -52,8 +52,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_ctrsyl_rec2(char *trana, char *tranb, int
 	*isgn, int *m, int *n, complex *a, int *lda, complex *b,
-	int *ldb, complex *c__, int *ldc, float *scale, int *info,
-	ftnlen trana_len, ftnlen tranb_len)
+	int *ldb, complex *c__, int *ldc, float *scale, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2,

--- a/src/ctrtri.c
+++ b/src/ctrtri.c
@@ -32,7 +32,7 @@ void RELAPACK_ctrtri(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("CTRTRI", &minfo);
+        LAPACK(xerbla)("CTRTRI", &minfo, 6);
         return;
     }
 

--- a/src/dgbtrf.c
+++ b/src/dgbtrf.c
@@ -32,7 +32,7 @@ void RELAPACK_dgbtrf(
         *info = -6;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DGBTRF", &minfo);
+        LAPACK(xerbla)("DGBTRF", &minfo, 6);
         return;
     }
 

--- a/src/dgemmt.c
+++ b/src/dgemmt.c
@@ -56,7 +56,7 @@ void RELAPACK_dgemmt(
     else if (*ldC < MAX(1, *n))
         info = 13;
     if (info) {
-        LAPACK(xerbla)("DGEMMT", &info);
+        LAPACK(xerbla)("DGEMMT", &info, 6);
         return;
     }
 

--- a/src/dgetrf.c
+++ b/src/dgetrf.c
@@ -26,7 +26,7 @@ void RELAPACK_dgetrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DGETRF", &minfo);
+        LAPACK(xerbla)("DGETRF", &minfo, 6);
         return;
     }
 

--- a/src/dlauum.c
+++ b/src/dlauum.c
@@ -28,7 +28,7 @@ void RELAPACK_dlauum(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DLAUUM", &minfo);
+        LAPACK(xerbla)("DLAUUM", &minfo, 6);
         return;
     }
 

--- a/src/dpbtrf.c
+++ b/src/dpbtrf.c
@@ -31,7 +31,7 @@ void RELAPACK_dpbtrf(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DPBTRF", &minfo);
+        LAPACK(xerbla)("DPBTRF", &minfo, 6);
         return;
     }
 

--- a/src/dpotrf.c
+++ b/src/dpotrf.c
@@ -28,7 +28,7 @@ void RELAPACK_dpotrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DPOTRF", &minfo);
+        LAPACK(xerbla)("DPOTRF", &minfo, 6);
         return;
     }
 

--- a/src/dsygst.c
+++ b/src/dsygst.c
@@ -36,7 +36,7 @@ void RELAPACK_dsygst(
         *info = -7;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DSYGST", &minfo);
+        LAPACK(xerbla)("DSYGST", &minfo, 6);
         return;
     }
 

--- a/src/dsytrf.c
+++ b/src/dsytrf.c
@@ -56,7 +56,7 @@ void RELAPACK_dsytrf(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DSYTRF", &minfo);
+        LAPACK(xerbla)("DSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/dsytrf_rec2.c
+++ b/src/dsytrf_rec2.c
@@ -27,7 +27,7 @@ static double c_b9 = 1.;
  * */
 /* Subroutine */ void RELAPACK_dsytrf_rec2(char *uplo, int *n, int *
 	nb, int *kb, double *a, int *lda, int *ipiv,
-	double *w, int *ldw, int *info, ftnlen uplo_len)
+	double *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2;

--- a/src/dsytrf_rook.c
+++ b/src/dsytrf_rook.c
@@ -56,7 +56,7 @@ void RELAPACK_dsytrf_rook(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DSYTRF", &minfo);
+        LAPACK(xerbla)("DSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/dsytrf_rook_rec2.c
+++ b/src/dsytrf_rook_rec2.c
@@ -27,7 +27,7 @@ static double c_b10 = 1.;
  * */
 /* Subroutine */ void RELAPACK_dsytrf_rook_rec2(char *uplo, int *n,
 	int *nb, int *kb, double *a, int *lda, int *ipiv,
-	double *w, int *ldw, int *info, ftnlen uplo_len)
+	double *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2;

--- a/src/dtgsyl.c
+++ b/src/dtgsyl.c
@@ -59,7 +59,7 @@ void RELAPACK_dtgsyl(
         *info = -20;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DTGSYL", &minfo);
+        LAPACK(xerbla)("DTGSYL", &minfo, 6);
         return;
     }
 

--- a/src/dtrsyl.c
+++ b/src/dtrsyl.c
@@ -45,7 +45,7 @@ void RELAPACK_dtrsyl(
         *info = -11;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DTRSYL", &minfo);
+        LAPACK(xerbla)("DTRSYL", &minfo, 6);
         return;
     }
 

--- a/src/dtrsyl_rec2.c
+++ b/src/dtrsyl_rec2.c
@@ -23,8 +23,7 @@ static int c_true = TRUE_;
 
 int RELAPACK_dtrsyl_rec2(char *trana, char *tranb, int *isgn, int
 	*m, int *n, double *a, int *lda, double *b, int *
-	ldb, double *c__, int *ldc, double *scale, int *info,
-	ftnlen trana_len, ftnlen tranb_len)
+	ldb, double *c__, int *ldc, double *scale, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2,

--- a/src/dtrtri.c
+++ b/src/dtrtri.c
@@ -32,7 +32,7 @@ void RELAPACK_dtrtri(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("DTRTRI", &minfo);
+        LAPACK(xerbla)("DTRTRI", &minfo, 6);
         return;
     }
 

--- a/src/sgbtrf.c
+++ b/src/sgbtrf.c
@@ -32,7 +32,7 @@ void RELAPACK_sgbtrf(
         *info = -6;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SGBTRF", &minfo);
+        LAPACK(xerbla)("SGBTRF", &minfo, 6);
         return;
     }
 

--- a/src/sgemmt.c
+++ b/src/sgemmt.c
@@ -56,7 +56,7 @@ void RELAPACK_sgemmt(
     else if (*ldC < MAX(1, *n))
         info = 13;
     if (info) {
-        LAPACK(xerbla)("SGEMMT", &info);
+        LAPACK(xerbla)("SGEMMT", &info, 6);
         return;
     }
 

--- a/src/sgetrf.c
+++ b/src/sgetrf.c
@@ -26,7 +26,7 @@ void RELAPACK_sgetrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SGETRF", &minfo);
+        LAPACK(xerbla)("SGETRF", &minfo, 6);
         return;
     }
 

--- a/src/slauum.c
+++ b/src/slauum.c
@@ -28,7 +28,7 @@ void RELAPACK_slauum(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SLAUUM", &minfo);
+        LAPACK(xerbla)("SLAUUM", &minfo, 6);
         return;
     }
 

--- a/src/spbtrf.c
+++ b/src/spbtrf.c
@@ -31,7 +31,7 @@ void RELAPACK_spbtrf(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SPBTRF", &minfo);
+        LAPACK(xerbla)("SPBTRF", &minfo, 6);
         return;
     }
 

--- a/src/spotrf.c
+++ b/src/spotrf.c
@@ -28,7 +28,7 @@ void RELAPACK_spotrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SPOTRF", &minfo);
+        LAPACK(xerbla)("SPOTRF", &minfo, 6);
         return;
     }
 

--- a/src/ssygst.c
+++ b/src/ssygst.c
@@ -36,7 +36,7 @@ void RELAPACK_ssygst(
         *info = -7;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SSYGST", &minfo);
+        LAPACK(xerbla)("SSYGST", &minfo, 6);
         return;
     }
 

--- a/src/ssytrf.c
+++ b/src/ssytrf.c
@@ -56,7 +56,7 @@ void RELAPACK_ssytrf(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SSYTRF", &minfo);
+        LAPACK(xerbla)("SSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/ssytrf_rec2.c
+++ b/src/ssytrf_rec2.c
@@ -27,7 +27,7 @@ static float c_b9 = 1.f;
  * */
 /* Subroutine */ void RELAPACK_ssytrf_rec2(char *uplo, int *n, int *
 	nb, int *kb, float *a, int *lda, int *ipiv, float *w,
-	int *ldw, int *info, ftnlen uplo_len)
+	int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2;

--- a/src/ssytrf_rook.c
+++ b/src/ssytrf_rook.c
@@ -56,7 +56,7 @@ void RELAPACK_ssytrf_rook(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("SSYTRF", &minfo);
+        LAPACK(xerbla)("SSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/ssytrf_rook_rec2.c
+++ b/src/ssytrf_rook_rec2.c
@@ -27,7 +27,7 @@ static float c_b10 = 1.f;
  * */
 /* Subroutine */ void RELAPACK_ssytrf_rook_rec2(char *uplo, int *n,
 	int *nb, int *kb, float *a, int *lda, int *ipiv, float *
-	w, int *ldw, int *info, ftnlen uplo_len)
+	w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2;

--- a/src/stgsyl.c
+++ b/src/stgsyl.c
@@ -59,7 +59,7 @@ void RELAPACK_stgsyl(
         *info = -20;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("STGSYL", &minfo);
+        LAPACK(xerbla)("STGSYL", &minfo, 6);
         return;
     }
 

--- a/src/strsyl.c
+++ b/src/strsyl.c
@@ -45,7 +45,7 @@ void RELAPACK_strsyl(
         *info = -11;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("STRSYL", &minfo);
+        LAPACK(xerbla)("STRSYL", &minfo, 6);
         return;
     }
 

--- a/src/strsyl_rec2.c
+++ b/src/strsyl_rec2.c
@@ -23,8 +23,7 @@ static int c_true = TRUE_;
 
 void RELAPACK_strsyl_rec2(char *trana, char *tranb, int *isgn, int
 	*m, int *n, float *a, int *lda, float *b, int *ldb, float *
-	c__, int *ldc, float *scale, int *info, ftnlen trana_len,
-	ftnlen tranb_len)
+	c__, int *ldc, float *scale, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2,

--- a/src/strtri.c
+++ b/src/strtri.c
@@ -32,7 +32,7 @@ void RELAPACK_strtri(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("STRTRI", &minfo);
+        LAPACK(xerbla)("STRTRI", &minfo, 6);
         return;
     }
 

--- a/src/zgbtrf.c
+++ b/src/zgbtrf.c
@@ -32,7 +32,7 @@ void RELAPACK_zgbtrf(
         *info = -6;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZGBTRF", &minfo);
+        LAPACK(xerbla)("ZGBTRF", &minfo, 6);
         return;
     }
 

--- a/src/zgemmt.c
+++ b/src/zgemmt.c
@@ -58,7 +58,7 @@ void RELAPACK_zgemmt(
     else if (*ldC < MAX(1, *n))
         info = 13;
     if (info) {
-        LAPACK(xerbla)("ZGEMMT", &info);
+        LAPACK(xerbla)("ZGEMMT", &info, 6);
         return;
     }
 

--- a/src/zgetrf.c
+++ b/src/zgetrf.c
@@ -26,7 +26,7 @@ void RELAPACK_zgetrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZGETRF", &minfo);
+        LAPACK(xerbla)("ZGETRF", &minfo, 6);
         return;
     }
 

--- a/src/zhegst.c
+++ b/src/zhegst.c
@@ -36,7 +36,7 @@ void RELAPACK_zhegst(
         *info = -7;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZHEGST", &minfo);
+        LAPACK(xerbla)("ZHEGST", &minfo, 6);
         return;
     }
 

--- a/src/zhetrf.c
+++ b/src/zhetrf.c
@@ -56,7 +56,7 @@ void RELAPACK_zhetrf(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZHETRF", &minfo);
+        LAPACK(xerbla)("ZHETRF", &minfo, 6);
         return;
     }
 

--- a/src/zhetrf_rec2.c
+++ b/src/zhetrf_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_zhetrf_rec2(char *uplo, int *n, int *
 	nb, int *kb, doublecomplex *a, int *lda, int *ipiv,
-	doublecomplex *w, int *ldw, int *info, ftnlen uplo_len)
+	doublecomplex *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/zhetrf_rook.c
+++ b/src/zhetrf_rook.c
@@ -56,7 +56,7 @@ void RELAPACK_zhetrf_rook(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZHETRF", &minfo);
+        LAPACK(xerbla)("ZHETRF", &minfo, 6);
         return;
     }
 

--- a/src/zhetrf_rook_rec2.c
+++ b/src/zhetrf_rook_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_zhetrf_rook_rec2(char *uplo, int *n,
 	int *nb, int *kb, doublecomplex *a, int *lda, int *
-	ipiv, doublecomplex *w, int *ldw, int *info, ftnlen uplo_len)
+	ipiv, doublecomplex *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/zlauum.c
+++ b/src/zlauum.c
@@ -28,7 +28,7 @@ void RELAPACK_zlauum(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZLAUUM", &minfo);
+        LAPACK(xerbla)("ZLAUUM", &minfo, 6);
         return;
     }
 

--- a/src/zpbtrf.c
+++ b/src/zpbtrf.c
@@ -31,7 +31,7 @@ void RELAPACK_zpbtrf(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZPBTRF", &minfo);
+        LAPACK(xerbla)("ZPBTRF", &minfo, 6);
         return;
     }
 

--- a/src/zpotrf.c
+++ b/src/zpotrf.c
@@ -28,7 +28,7 @@ void RELAPACK_zpotrf(
         *info = -4;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZPOTRF", &minfo);
+        LAPACK(xerbla)("ZPOTRF", &minfo, 6);
         return;
     }
 

--- a/src/zsytrf.c
+++ b/src/zsytrf.c
@@ -56,7 +56,7 @@ void RELAPACK_zsytrf(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZSYTRF", &minfo);
+        LAPACK(xerbla)("ZSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/zsytrf_rec2.c
+++ b/src/zsytrf_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_zsytrf_rec2(char *uplo, int *n, int *
 	nb, int *kb, doublecomplex *a, int *lda, int *ipiv,
-	doublecomplex *w, int *ldw, int *info, ftnlen uplo_len)
+	doublecomplex *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/zsytrf_rook.c
+++ b/src/zsytrf_rook.c
@@ -56,7 +56,7 @@ void RELAPACK_zsytrf_rook(
 
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZSYTRF", &minfo);
+        LAPACK(xerbla)("ZSYTRF", &minfo, 6);
         return;
     }
 

--- a/src/zsytrf_rook_rec2.c
+++ b/src/zsytrf_rook_rec2.c
@@ -26,7 +26,7 @@ static int c__1 = 1;
  * */
 /* Subroutine */ void RELAPACK_zsytrf_rook_rec2(char *uplo, int *n,
 	int *nb, int *kb, doublecomplex *a, int *lda, int *
-	ipiv, doublecomplex *w, int *ldw, int *info, ftnlen uplo_len)
+	ipiv, doublecomplex *w, int *ldw, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, w_dim1, w_offset, i__1, i__2, i__3, i__4;

--- a/src/ztgsyl.c
+++ b/src/ztgsyl.c
@@ -58,7 +58,7 @@ void RELAPACK_ztgsyl(
         *info = -20;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZTGSYL", &minfo);
+        LAPACK(xerbla)("ZTGSYL", &minfo, 6);
         return;
     }
 

--- a/src/ztrsyl.c
+++ b/src/ztrsyl.c
@@ -43,7 +43,7 @@ void RELAPACK_ztrsyl(
         *info = -11;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZTRSYL", &minfo);
+        LAPACK(xerbla)("ZTRSYL", &minfo, 6);
         return;
     }
 

--- a/src/ztrsyl_rec2.c
+++ b/src/ztrsyl_rec2.c
@@ -53,7 +53,7 @@ static int c__1 = 1;
 /* Subroutine */ void RELAPACK_ztrsyl_rec2(char *trana, char *tranb, int
 	*isgn, int *m, int *n, doublecomplex *a, int *lda,
 	doublecomplex *b, int *ldb, doublecomplex *c__, int *ldc,
-	double *scale, int *info, ftnlen trana_len, ftnlen tranb_len)
+	double *scale, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2,

--- a/src/ztrtri.c
+++ b/src/ztrtri.c
@@ -32,7 +32,7 @@ void RELAPACK_ztrtri(
         *info = -5;
     if (*info) {
         const int minfo = -*info;
-        LAPACK(xerbla)("ZTRTRI", &minfo);
+        LAPACK(xerbla)("ZTRTRI", &minfo, 6);
         return;
     }
 


### PR DESCRIPTION
Add missing ftnlen arguments to xerbla calls.
Remove unused ftlen arguments from f2c-generated code.